### PR TITLE
Add Padding

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -132,3 +132,14 @@ def shuffle_split_scale(X_jets, X_photons, X_muons, y, w):
     X_muons_train, X_muons_test = _scale(X_muons_train, X_muons_test)
 
     return X_jets_train, X_jets_test, X_photons_train, X_photons_test, X_muons_train, X_muons_test, Y_train, Y_test, W_train, W_test
+
+
+def zero_padding(X, max_length):
+    '''
+
+    '''
+    data = -999 * np.ones((X.shape[0], max_length, X.shape[1]), dtype='float32')
+    for i, row in enumerate(X):
+        data[i, :min(len(row[0]), max_length), :] = np.array(row.tolist()).T[:min(len(row[0]), max_length), :]
+
+    return data

--- a/data_processing.py
+++ b/data_processing.py
@@ -134,11 +134,22 @@ def shuffle_split_scale(X_jets, X_photons, X_muons, y, w):
     return X_jets_train, X_jets_test, X_photons_train, X_photons_test, X_muons_train, X_muons_test, Y_train, Y_test, W_train, W_test
 
 
-def zero_padding(X, max_length):
+def padding(X, max_length, value=-999):
     '''
-
+    Transforms X to a 3D array where the dimensions correspond to [n_ev, n_particles, n_features].
+    n_particles is now fixed and equal to max_length.
+    If the number of particles in an event was < max_length, the missing particles will be filled with default values
+    If the number of particles in an event was > max_length, the excess particles will be removed
+    Args:
+        X: ndarray [n_ev, n_features] with an arbitrary number of particles per event
+        max_length: int, the number of particles to keep per event 
+        value (optional): the value to input in case there are not enough particles in the event, default=-999
+    Returns:
+        data: ndarray [n_ev, n_particles, n_features], padded version of X with fixed number of particles
+    Note: 
+        Use Masking to avoid the particles with artificial entries = -999
     '''
-    data = -999 * np.ones((X.shape[0], max_length, X.shape[1]), dtype='float32')
+    data = value * np.ones((X.shape[0], max_length, X.shape[1]), dtype='float32')
     for i, row in enumerate(X):
         data[i, :min(len(row[0]), max_length), :] = np.array(row.tolist()).T[:min(len(row[0]), max_length), :]
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,5 +1,5 @@
 import json
-from data_processing import read_in, shuffle_split_scale
+from data_processing import read_in, shuffle_split_scale, zero_padding
 import pandautils as pup
 import cPickle
 from plotting import plot_inputs
@@ -93,7 +93,7 @@ def main(json_config, exclude_vars):
             }, 
             open('processed_data_' + sha(class_files_dict) + '.pkl', 'wb'),
             protocol=cPickle.HIGHEST_PROTOCOL)
-    
+
     # -- plot distributions:
     '''
     This should produce normed, weighted histograms of the input distributions for all variables
@@ -109,6 +109,19 @@ def main(json_config, exclude_vars):
         w_train, w_test,
         varlist 
         )
+
+    X_jets_train, X_jets_test, \
+    X_photons_train, X_photons_test, \
+    X_muons_train, X_muons_test = map(zero_padding, 
+        [
+            X_jets_train, X_jets_test, 
+            X_photons_train, X_photons_test, 
+            X_muons_train, X_muons_test
+        ],
+        [5, 5, 3, 3, 2, 2]
+    )
+
+    print  X_jets_train.shape, X_photons_train.shape
 
     # # -- train
     # # design a Keras NN with three RNN streams (jets, photons, muons)

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,5 +1,5 @@
 import json
-from data_processing import read_in, shuffle_split_scale, zero_padding
+from data_processing import read_in, shuffle_split_scale, padding
 import pandautils as pup
 import cPickle
 from plotting import plot_inputs
@@ -112,7 +112,7 @@ def main(json_config, exclude_vars):
 
     X_jets_train, X_jets_test, \
     X_photons_train, X_photons_test, \
-    X_muons_train, X_muons_test = map(zero_padding, 
+    X_muons_train, X_muons_test = map(padding, 
         [
             X_jets_train, X_jets_test, 
             X_photons_train, X_photons_test, 
@@ -120,8 +120,6 @@ def main(json_config, exclude_vars):
         ],
         [5, 5, 3, 3, 2, 2]
     )
-
-    print  X_jets_train.shape, X_photons_train.shape
 
     # # -- train
     # # design a Keras NN with three RNN streams (jets, photons, muons)


### PR DESCRIPTION
Padding is required for the feature matrix X to have a fixed number of particles per event. If the original number of particles in a specific event is less than the desired `max_length`, then the missing particles will be added by inserting a default value of -999 for all their features. If the original number of particle was greater than `max_length`, the excess particles will be truncated and removed.
